### PR TITLE
feat: use wallpapers set in config.json

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -15,7 +15,7 @@ import (
 const (
 	AppName        = "WallpaperEngine"
 	AppDescription = "A simple wallpaper setter."
-	AppVersion     = "1.0.2"
+	AppVersion     = "1.0.3"
 	AppAuthor      = "@mikeunge"
 )
 
@@ -37,6 +37,7 @@ func init() {
 
 	if args.Debug {
 		log.SetLogLevel("debug")
+		log.SetOutput(false)
 		log.Info("WallpaperEngine running in debug mode")
 	} else if args.Verbose {
 		log.SetLogLevel("info")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -45,7 +45,7 @@ func New(app AppInfo) (Args, error) {
 
 	if *currentWallpaper {
         if !helpers.FileExists(app.WallpaperPath) {
-            fmt.Printf("Wallpaper does not exist: %s\n", app.WallpaperPath)
+            fmt.Printf("Could not get current wallpaper, file does not exist: %s\n", app.WallpaperPath)
             os.Exit(1)
         }
 

--- a/internal/wallpaper/wallpaper.go
+++ b/internal/wallpaper/wallpaper.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetWallpaper(appConfig *config.Config, wallpaper string) (string, error) {
-	// Check if wp was provided & check if it exists
+	// Check if wallpaper with full path was provided & check if it the file exists
 	if len(wallpaper) > 0 {
 		if helpers.FileExists(wallpaper) {
 			log.Info("Provided wallpaper was found, %s", wallpaper)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -27,17 +27,24 @@ func SetLogLevel(level string) {
 	}
 }
 
-func init() {
-	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		panic(fmt.Sprintf("error opening file: %v", err))
-	}
+func SetOutput(fileOut bool) {
+    if fileOut {
+        file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+        if err != nil {
+            panic(fmt.Sprintf("error opening file: %v", err))
+        }
+        log.SetOutput(file)
+    } else {
+        log.SetOutput(os.Stdout)
+    }
+}
 
+func init() {
 	// set up a new json logger, with loglevel warn and write to file
 	log = logrus.New()
 	log.Formatter = &logrus.JSONFormatter{}
-	log.SetLevel(logrus.WarnLevel)
-	log.SetOutput(file)
+	SetLogLevel("warn")
+    SetOutput(true)
 }
 
 func Debug(format string, v ...interface{}) {


### PR DESCRIPTION
This PR introduces some new features that include:
- using wallpapers set in the config.json (_like the blacklist but for __only use these__ type of stuff_)
- minor fixes and improvements (_like debug prints to stdout, more helpful comments in the codebase, ..._)
