### PR TITLE
fix: logging path

### DIFF
--- a/internal/wallpaper/wallpaper.go
+++ b/internal/wallpaper/wallpaper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mikeunge/WallpaperEngine/internal/config"
 	"github.com/mikeunge/WallpaperEngine/pkg/cache"
 	"github.com/mikeunge/WallpaperEngine/pkg/helpers"
+	"github.com/mikeunge/WallpaperEngine/pkg/image_helpers"
 	log "github.com/mikeunge/WallpaperEngine/pkg/logger"
 )
 
@@ -27,14 +28,14 @@ func GetWallpaper(appConfig *config.Config, wallpaper string) (string, error) {
 		return "", err
 	}
 
-	images, err := helpers.FilterImages(files, appConfig.ValidExtensions, appConfig.Blacklist)
+	images, err := image_helpers.FilterImages(files, appConfig.ValidExtensions, appConfig.Blacklist)
 	if err != nil {
 		log.Error("%+v", err)
 		return "", err
 	}
 
 	if len(wallpaper) > 0 {
-		image, err := helpers.FindImageInImages(wallpaper, images)
+		image, err := image_helpers.FindImageInImages(wallpaper, images)
 		if err != nil {
 			log.Warn("Filtered through all the images but there seems to be no an error: %+v", err)
 			log.Info("Returning random image")

--- a/pkg/image_helpers/image_helpers.go
+++ b/pkg/image_helpers/image_helpers.go
@@ -1,9 +1,10 @@
-package helpers
+package image_helpers
 
 import (
 	"fmt"
 	"strings"
 
+	"github.com/mikeunge/WallpaperEngine/pkg/helpers"
 	log "github.com/mikeunge/WallpaperEngine/pkg/logger"
 )
 
@@ -33,7 +34,7 @@ func FilterImages(imagePaths []string, validExtensions []string, blacklist []str
 
 func FindImageInImages(image string, images []string) (string, error) {
 	for i := 0; i < len(images); i++ {
-		filename := GetFileName(images[i])
+		filename := helpers.GetFileName(images[i])
 		if filename == image {
 			return images[i], nil
 		}
@@ -47,7 +48,7 @@ func isBlacklisted(path string, blacklist []string) bool {
 	for i := 0; i < len(blacklist); i++ {
 		if path == blacklist[i] {
 			return true
-		} else if GetFileName(path) == blacklist[i] {
+		} else if helpers.GetFileName(path) == blacklist[i] {
 			return true
 		}
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mikeunge/WallpaperEngine/pkg/helpers"
 	"github.com/sirupsen/logrus"
 )
 
 var (
 	log         *logrus.Logger
-	logFilePath = "/tmp/wallpaper-engine.log"
+	logFilePath = "~/.local/share/wallpaper-engine.log"
 )
 
 func SetLogLevel(level string) {
@@ -28,6 +29,7 @@ func SetLogLevel(level string) {
 }
 
 func SetOutput(fileOut bool) {
+    logFilePath = helpers.SanitizePath(logFilePath)
     if fileOut {
         file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
         if err != nil {


### PR DESCRIPTION
Move the logging path from ```/tmp/wallpaper-engine.log``` to ```~/.local/share/wallpaper-engine.log```.
Also, because of the helpers.SanitizePath function call I ran into a dependency cycle, so I moved the helpers/images.go into it's separate package because it consumed the logger package.